### PR TITLE
useframev2

### DIFF
--- a/src/CanAnalyzer.cpp
+++ b/src/CanAnalyzer.cpp
@@ -7,6 +7,7 @@
 CanAnalyzer::CanAnalyzer() : Analyzer2(), mSettings( new CanAnalyzerSettings() ), mSimulationInitilized( false )
 {
     SetAnalyzerSettings( mSettings.get() );
+    UseFrameV2();
 }
 
 CanAnalyzer::~CanAnalyzer()


### PR DESCRIPTION
This won't build until the new UseFrameV2(); Function has become an official part of the SDK. In the meantime, do not use `UseFrameV2();`, as it will fail to build.